### PR TITLE
add known bugs page

### DIFF
--- a/_sidebar.md
+++ b/_sidebar.md
@@ -45,3 +45,4 @@
 * Support
   * [Help & Support](/docs/support.md)
   * [License](/docs/license.md)
+  * [Known Bugs](/docs/knownbugs.md)

--- a/docs/knownbugs.md
+++ b/docs/knownbugs.md
@@ -1,0 +1,22 @@
+# Known Bugs in the Platform
+
+Our Github repository keeps track of all bugs that have been submitted so far. Below is a list of the current bugs that have not yet been resolved. For the full list, please visit: 
+
+https://github.com/ITISFoundation/osparc-issues/issues
+
+
+## From Github
+<div id="script_1"></div>
+<script type="text/javascript">
+    var urlToGetAllOpenBugs = "https://api.github.com/repos/ITISFoundation/osparc-issues/issues?state=open&labels=bug&sort:reactions-+1-desc";
+    $(document).ready(function () {
+        $.getJSON(urlToGetAllOpenBugs, function (allIssues) {
+            $.each(allIssues, function (i, issue) {
+                $("#script_1")
+                    .append("</br><b>" + issue.number + " - " + issue.title + "</b></br>")
+                    .append("created at: " + issue.created_at)
+                    .append("&nbsp;<a href="+issue.html_url+">link</a></br>");
+                });
+        });
+    });
+</script> 

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
       auto2top: true,
       subMaxLevel: 1,
       loadNavbar: true,
+      executeScript: true
     }
   </script>
   <!-- <script src="//unpkg.com/docsify-pagination/dist/docsify-pagination.min.js"></script> -->
@@ -31,6 +32,7 @@
   <script src="lib/plugins/search.min.js"></script>
   <script src="lib/plugins/zoom-image.min.js"></script>
   <script src="lib/plugins/footer.js"></script>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>  <!-- Jquery for GitHub issues -->
   <script src="//unpkg.com/docsify-sidebar-collapse/dist/docsify-sidebar-collapse.min.js"></script> -->
 </body>
 


### PR DESCRIPTION
## What do these changes do?

Adds a page for known bugs that auto-populates from osparc-issues

## Related issue number

closes https://github.com/ITISFoundation/osparc-issues/issues/415

## Checklist

- [x] I think the documentation is well written and up to date
- [ ] Do NOTE have very large media files (e.g. photos, videos, etc)
- [x] My spell-checker passes
- [ ] If you write a new section, i take ownership adding my user in .github/CODEOWNERS
